### PR TITLE
Use == for function comparison

### DIFF
--- a/asyncdef/emitter/emitter.py
+++ b/asyncdef/emitter/emitter.py
@@ -151,7 +151,7 @@ class Emitter:
         )
         for offset, _listener in enumerate(raw_listeners):
 
-            if listener is _listener:
+            if listener == _listener:
 
                 break
 

--- a/asyncdef/emitter/test_emitter.py
+++ b/asyncdef/emitter/test_emitter.py
@@ -144,6 +144,50 @@ def test_remove_removes_listeners():
     assert listener not in list(instance.listeners(event))
 
 
+def test_remove_removes_method():
+    """Check that remove removes object methods."""
+    instance = emitter.Emitter()
+    event = 'an_event'
+
+    class Listener:
+
+        """An object with a listener method."""
+
+        def listen(self):
+            """Do nothing."""
+            return None
+
+    listener = Listener()
+    instance.on(event, listener.listen)
+    assert instance.listeners_count(event) == 1
+    assert listener.listen in list(instance.listeners(event))
+    instance.remove(event, listener.listen)
+    assert instance.listeners_count(event) == 0
+    assert listener.listen not in list(instance.listeners(event))
+
+
+def test_remove_removes_classmethod():
+    """Check that remove removes object class methods."""
+    instance = emitter.Emitter()
+    event = 'an_event'
+
+    class Listener:
+
+        """An object with a listener method."""
+
+        @classmethod
+        def listen(cls):
+            """Do nothing."""
+            return None
+
+    instance.on(event, Listener.listen)
+    assert instance.listeners_count(event) == 1
+    assert Listener.listen in list(instance.listeners(event))
+    instance.remove(event, Listener.listen)
+    assert instance.listeners_count(event) == 0
+    assert Listener.listen not in list(instance.listeners(event))
+
+
 def test_remove_allows_missing():
     """Check if remove works when there are no listeners."""
     instance = emitter.Emitter()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as readmefile:
 
 setup(
     name='asyncdef.emitter',
-    version='0.1.0',
+    version='0.1.1',
     url='https://github.com/asyncdef/emitter',
     description='Tools for handling async events.',
     author="Kevin Conway",


### PR DESCRIPTION
The 'is' operator only works for functions and does not return True
when comparing the identity of object methods. Switch to '==' to
resolve this issue.
